### PR TITLE
Pin scikit-build-core version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ documentation = "https://github.com/aewallin/opencamlib"
 repository = "https://github.com/aewallin/opencamlib"
 
 [build-system]
-requires = ["scikit-build-core", "pybind11"]
+requires = ["scikit-build-core<0.10", "pybind11"]
 build-backend = "scikit_build_core.build"
 
 [tool.scikit-build]


### PR DESCRIPTION
Pin scikit-build-core version < 0.10 in pyproject.toml. Otherwise can replace cmake.verbose with build.verbose.

Previous build error:

Call to 'scikit_build_core.build.build_wheel' failed (exit status: 7)

[stderr]
ERROR: Use build.verbose instead of cmake.verbose for scikit-build-core >= 0.10